### PR TITLE
Clone openj9 repositories using https by default

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -51,7 +51,7 @@ declare -A commands
 declare -A shas
 
 pflag="false"
-base_git_url=git@github.com
+base_git_url=https://github.com
 
 for i in "$@"
 do
@@ -132,7 +132,7 @@ for i in "${!default_j9repos[@]}" ; do
 		fi
 		cd -
 	else
-		git_url=${base_git_url}:${default_j9repos[$i]}.git
+		git_url=${base_git_url}/${default_j9repos[$i]}
 
 		if [ ${j9repos[$i]+_} ]; then
 			git_url="${j9repos[$i]}"


### PR DESCRIPTION
Eclipse OpenJ9's landing page describes a series of commands that
demonstrate how to build OpenJDK with OpenJ9 using a Docker file.
Following those instructions, the get_sources.sh command fails
because get_j9_sources.sh uses ssh to try to clone the openj9 and
omr repositories and that doesn't work out-of-the-box in a docker
container unless git has been configured to authenticate github.com
But https works just fine, so let's use https as the default. The
command line options can override with ssh-style repository names
if desired.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>