### PR TITLE
Derive openjdk sha and tag more reliably

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -127,8 +127,8 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
 
 AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
 [
-  OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags`
+  OPENJDK_SHA=`git -C $SRC_ROOT rev-list --tags --abbrev-commit --max-count=1`
+  OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "${OPENJDK_SHA}"`
   AC_SUBST(OPENJDK_SHA)
   AC_SUBST(OPENJDK_TAG)
 ])

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -17119,8 +17119,8 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
 
 
 
-  OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags`
+  OPENJDK_SHA=`git -C $SRC_ROOT rev-list --tags --abbrev-commit --max-count=1`
+  OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "${OPENJDK_SHA}"`
 
 
 


### PR DESCRIPTION
In some scenarios, for example when working with a shallow clone,
the git commands used to derive the latest SHA and build tag do
not work, resulting in uninvormative output from java -version.

This commit updates the git commands used to derive the SHA and
then to map to the build tag so that they work correctly even with
a shallow clone of the repository.

Fixes: #4
Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>