### PR TITLE
Fix discovery of SHA and recent tag

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -155,8 +155,8 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
 
 AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
 [
-  OPENJDK_SHA=`git -C $SRC_ROOT rev-list --tags --abbrev-commit --max-count=1`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "${OPENJDK_SHA}"`
+  OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
+  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags "${OPENJDK_SHA}"`
   AC_SUBST(OPENJDK_SHA)
   AC_SUBST(OPENJDK_TAG)
 ])

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -5245,7 +5245,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1506631770
+DATE_WHEN_GENERATED=1506701929
 
 ###############################################################################
 #
@@ -17150,8 +17150,8 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
 
 
 
-  OPENJDK_SHA=`git -C $SRC_ROOT rev-list --tags --abbrev-commit --max-count=1`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "${OPENJDK_SHA}"`
+  OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
+  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags "${OPENJDK_SHA}"`
 
 
 

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5186,7 +5186,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1506631770
+DATE_WHEN_GENERATED=1506701929
 
 ###############################################################################
 #


### PR DESCRIPTION
Revert the computation of the openj9-openjdk-jdk9 SHA.

Use '--abbrev=0' to get most recent tag on the current branch; otherwise we might find a tag on some other branch.