### PR TITLE
Use default c compiler

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -63,6 +63,13 @@ else
   OMR_EXTRA_CONFIGURE_ARGS := "--enable-warnings-as-errors OMR_TREAT_WARNINGS_AS_ERRORS=1"
 endif
 
+# disable mingw on windows, use default c compiler
+ifeq ($(OPENJDK_TARGET_OS),windows)
+  EXPORT_NO_USE_MINGW := NO_USE_MINGW=true
+else
+  EXPORT_NO_USE_MINGW :=
+endif
+
 .PHONY : \
 	build-j9 \
 	clean-j9 \
@@ -247,7 +254,7 @@ run-preprocessors-j9 : stage-j9 \
 
 build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUT_ROOT)/vm
-	(export OPENJ9_BUILD=true && cd $(OUTPUT_ROOT)/vm && $(MAKE) $(MAKEFLAGS) all)
+	(export OPENJ9_BUILD=true $(EXPORT_NO_USE_MINGW) && cd $(OUTPUT_ROOT)/vm && $(MAKE) $(MAKEFLAGS) all)
 	@$(ECHO) OpenJ9 compile complete
 	# jvm and jsig are required for compiling other java.base support natives
 	@$(MKDIR) -p $(OUTPUT_ROOT)/support/modules_libs/java.base/server/


### PR DESCRIPTION
Openj9 requires mingw for compilation on windows
Set NO_USE_MINGW environment variable to use the default compiler (microsoft c compiler) instead

Fixes #50

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>