### PR TITLE
Getting sources should stop on the first error

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,12 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017 All Rights Reserved
 # ===========================================================================
-# 
+#
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -16,9 +16,12 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
+#
 # ===========================================================================
-    
+
+# exit immediately if any unexpected error occurs
+set -e
+
 usage() {
 	echo "Usage: $0 [-h|--help] [-openj9-repo=<j9vm repo url>] [-openj9-branch=<branch>] [-openj9-sha=<commit sha>] [... other OpenJ9 repositories and branches options] [-parallel=<true|false>]"
 	echo "where:"
@@ -30,144 +33,130 @@ usage() {
 	echo "  -omr-repo         the OpenJ9/omr repository url: https://github.com/eclipse/openj9-omr.git"
 	echo "                    or git@github.com:<namespace>/openj9-omr.git"
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
-	echo "  -omr-sha           a commit SHA for the omr repository"
+	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo ""
 	exit 1
 }
 
 # require bash 4.0 or later to support associative arrays
-bash_version=`bash --version | sed -n 1p`
-if [[ $bash_version != *"version 4."* ]] ; then
+if [ "0${BASH_VERSINFO[0]}" -lt 4 ] ; then
 	echo "Bash version 4.0 or later is required!"
 	exit 1
 fi
 
-declare -A j9repos
 declare -A branches
-declare -A default_j9repos=( [openj9]=eclipse/openj9 [omr]=eclipse/openj9-omr )
-declare -A default_branches=( [openj9]=master [omr]=openj9 )
 declare -A commands
+declare -A git_urls
 declare -A shas
 
-pflag="false"
-base_git_url=https://github.com
+git_urls[openj9]=https://github.com/eclipse/openj9
+branches[openj9]=master
 
-for i in "$@"
-do
+git_urls[omr]=https://github.com/eclipse/openj9-omr
+branches[omr]=openj9
+
+pflag=false
+
+for i in "$@" ; do
 	case $i in
 		-h | --help )
-		usage
-		;;
-
-		-r=* | --revision=* )
-		hgtag="${i#*=}"
-		;;
+			usage
+			;;
 
 		-openj9-repo=* )
-		j9repos[openj9]="${i#*=}"
-		;;
+			git_urls[openj9]="${i#*=}"
+			;;
 
 		-openj9-branch=* )
-		branches[openj9]="${i#*=}"
-		;;
+			branches[openj9]="${i#*=}"
+			;;
 
 		-openj9-sha=* )
-		shas[openj9]="${i#*=}"
-		;;
+			shas[openj9]="${i#*=}"
+			;;
 
 		-omr-repo=* )
-		j9repos[omr]="${i#*=}"
-		;;
+			git_urls[omr]="${i#*=}"
+			;;
 
 		-omr-branch=* )
-		branches[omr]="${i#*=}"
-		;;
+			branches[omr]="${i#*=}"
+			;;
 
 		-omr-sha=* )
-		shas[omr]="${i#*=}"
-		;;
+			shas[omr]="${i#*=}"
+			;;
 
 		-parallel=* )
-		pflag="${i#*=}"
-		;;
+			pflag="${i#*=}"
+			;;
 
 		'--' ) # no more options
-		usage
-		;;
+			break
+			;;
 
 		-*) # bad option
-		usage
-		;;
+			usage
+			;;
 
 		*) # bad option
-		usage
-		;;
+			usage
+			;;
 	esac
 done
-
-git=`which git`
 
 # clone OpenJ9 repos
 date '+[%F %T] Get OpenJ9 sources'
 START_TIME=$(date +%s)
 
-for i in "${!default_j9repos[@]}" ; do
-	branch=${default_branches[$i]}
-	if [ ${branches[$i]+_} ]; then
-		branch=${branches[$i]}
-	fi
+for i in "${!git_urls[@]}" ; do
+	branch=${branches[$i]}
 
-	if [ -d ${i} ]; then
+	if [ -d ${i} ] ; then
 		echo
 		echo "Update ${i} source"
 		echo
 
 		cd ${i}
-		git pull --rebase origin ${branch} || exit $?
+		git pull --rebase origin ${branch}
 
-		if [ -f .gitmodules ]; then
-			git pull --rebase --recurse-submodules=yes || exit $?
-			git submodule update --rebase --recursive || exit $?
+		if [ -f .gitmodules ] ; then
+			git pull --rebase --recurse-submodules=yes
+			git submodule update --rebase --recursive
 		fi
-		cd -
+		cd - > /dev/null
 	else
-		git_url=${base_git_url}/${default_j9repos[$i]}
-
-		if [ ${j9repos[$i]+_} ]; then
-			git_url="${j9repos[$i]}"
-		fi
-
-		git_clone_command="${git} clone --recursive -b ${branch} ${git_url} ${i}"
-		commands[$i]=${git_clone_command}
+		git_clone_command="git clone --recursive -b ${branch} ${git_urls[$i]} ${i}"
+		commands[$i]=$git_clone_command
 
 		echo
 		echo "Clone repository: ${i}"
 		echo
 
-		if [ ${pflag} = "true" ] ; then
+		if [ ${pflag} = true ] ; then
 			# run git clone in parallel
-			( ${git_clone_command} ; echo "$?" > /tmp/${i}.pid.rc ) 2>&1 &
+			( if $git_clone_command ; then echo 0 ; else echo $? ; fi ) > /tmp/${i}.pid.rc 2>&1 &
 		else
-			${git_clone_command} || exit $?
+			$git_clone_command
 		fi
 	fi
 done
 
-if [ ${pflag} = "true" ] ; then
-	# Wait for all subprocesses to complete
+if [ ${pflag} = true ] ; then
+	# wait for all subprocesses to complete
 	wait
 fi
 
 END_TIME=$(date +%s)
 date "+[%F %T] OpenJ9 clone repositories finished in $(($END_TIME - $START_TIME)) seconds"
 
-for i in "${!default_j9repos[@]}" ; do
-	if [ -e /tmp/${i}.pid.rc ]; then
+for i in "${!git_urls[@]}" ; do
+	if [ -e /tmp/${i}.pid.rc ] ; then
 		# check if the git clone repository command failed
-		rc=`cat /tmp/${i}.pid.rc | tr -d ' \n\r'`
+		rc=$(cat /tmp/${i}.pid.rc | tr -d ' \n\r')
 
-		if [ "$rc" -ne "0" ]; then
+		if [ "$rc" != 0 ] ; then
 			echo "ERROR: repository ${i} exited abnormally!"
 			cat /tmp/${i}.pid.rc
 			echo "Re-run: ${commands[$i]}"
@@ -183,13 +172,13 @@ for i in "${!default_j9repos[@]}" ; do
 		fi
 	fi
 
-	if [ ${shas[$i]+_} ]; then
+	if [ "x${shas[$i]}" != x ] ; then
 		echo
 		echo "Update ${i} to commit ID: ${shas[$i]}"
 		echo
 
 		cd ${i}
-		git checkout ${shas[$i]} || exit $?
-		cd -
+		git checkout ${shas[$i]}
+		cd - > /dev/null
 	fi
 done

--- a/get_source.sh
+++ b/get_source.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
@@ -25,6 +25,9 @@
 # questions.
 #
 
+# exit immediately if any unexpected error occurs
+set -e
+
 usage() {
 	echo "Usage: $0 [-h|--help] [... other j9 options] [-parallel=<true|false>]"
 	echo "where:"
@@ -37,9 +40,9 @@ usage() {
 	echo "  -omr-repo         the OpenJ9/omr repository url: https://github.com/eclipse/openj9-omr.git"
 	echo "                    or git@github.com:<namespace>/openj9-omr.git"
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
-	echo "  -omr-sha           a commit SHA for the omr repository"
+	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
-	echo " "
+	echo ""
 	exit 1
 }
 
@@ -71,4 +74,3 @@ done
 
 # Get clones of OpenJ9 absent repositories
 bash closed/get_j9_source.sh ${j9options}
-


### PR DESCRIPTION
I've seen a few automatic builds fail because the SHA of a PR merge commit becomes stale (happens if some unrelated PR is merged in the interim). The build should not continue (with the wrong code).

* improve bash version check
* more careful use of quotes
* simpler handling of defaults
* remove --revision option (mercurial)
* don't print usage when encountering the '--' option