### PR TITLE
Use tar's '-m' rather than '--touch' to support older toolchains.

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -127,9 +127,10 @@ endef
 
 OPENJ9_MARKER_FILE := .up-to-date
 
+# Use '-m' / '--touch' to avoid file modification times.  `-m` works with older tar tools
 define openj9_copy_tree_impl
   @$(MKDIR) -p $1
-  @$(TAR) --create --directory=$2 $(if $(wildcard $1/$(OPENJ9_MARKER_FILE)),--newer=$1/$(OPENJ9_MARKER_FILE)) --exclude-vcs . | $(TAR) --extract --directory=$1 --touch
+  @$(TAR) --create --directory=$2 $(if $(wildcard $1/$(OPENJ9_MARKER_FILE)),--newer=$1/$(OPENJ9_MARKER_FILE)) --exclude-vcs . | $(TAR) --extract --directory=$1 -m
   @$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
 


### PR DESCRIPTION
-m is equivalent to --touch and is supported on older versions of
the tar tool.  This is especially important for mac osx which
doesn't have gnu tar by default.

i.e.: on macosx the default tar supports:
```
  -m    Don't restore modification times
```
while gnu tar supports
```
 -m, --touch                don't extract file modified time
```

Using `-m` is more portable than `--touch`, even though the latter is clearer.