### PR TITLE
Changes to build process to allow building of OpenJ9 on AIX

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -51,10 +51,8 @@ OPENJ9_MISC_FILES := \
 OPENJ9_NOTICE_FILES := openj9-notices.html
 OPENJ9_REDIRECTOR := redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX)
 
-# we should try using the makeflags as defined by openjdk (issue 59)
-NUMCPU := $(shell grep -c ^processor /proc/cpuinfo)
-#$(info NUMCPU = $(NUMCPU))
-override MAKEFLAGS := -j $(NUMCPU)
+# openjdk makeflags don't work with openj9/omr native compiles; override with number of cpus which openj9 and omr need supplied
+override MAKEFLAGS := -j $(JOBS)
 
 # honour the --disable-warnings-as-errors configure parameter during compilation of OMR
 ifeq (false,$(WARNINGS_AS_ERRORS))
@@ -212,7 +210,7 @@ OPENJ9_VERSION_VARS := \
 	#
 
 OPENJ9_VERSION_SCRIPT := \
-	$(foreach var,$(OPENJ9_VERSION_VARS),-e 's:@${var}@:$(value $(var)):g')
+	$(foreach var,$(OPENJ9_VERSION_VARS),-e "s|@${var}@|$(value $(var))|g")
 
 $(OUTPUT_ROOT)/vm/util/openj9_version_info.h : $(SRC_ROOT)/closed/openj9_version_info.h.in
 	@$(MKDIR) -p $(@D)

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -121,6 +121,9 @@ AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],
     s390x)
       OPENJ9_CPU=390-64
       ;;
+    powerpc64)
+      OPENJ9_CPU=ppc-64
+      ;;
     *)
       AC_MSG_ERROR([unsupported OpenJ9 cpu $1])
       ;;
@@ -146,6 +149,8 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
   elif test "x$OPENJ9_CPU" = x390-64; then
     OPENJ9_PLATFORM_CODE=xz64
+  elif test "x$OPENJ9_CPU" = xppc-64; then
+    OPENJ9_PLATFORM_CODE=ap64
   else
     AC_MSG_ERROR([Unsupported OpenJ9 cpu ${OPENJ9_CPU}, contact support team!])
   fi

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -5245,7 +5245,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1506706543
+DATE_WHEN_GENERATED=1507288529
 
 ###############################################################################
 #
@@ -17120,6 +17120,9 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
     s390x)
       OPENJ9_CPU=390-64
       ;;
+    powerpc64)
+      OPENJ9_CPU=ppc-64
+      ;;
     *)
       as_fn_error $? "unsupported OpenJ9 cpu $build_cpu" "$LINENO" 5
       ;;
@@ -17141,6 +17144,8 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
     OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
   elif test "x$OPENJ9_CPU" = x390-64; then
     OPENJ9_PLATFORM_CODE=xz64
+  elif test "x$OPENJ9_CPU" = xppc-64; then
+    OPENJ9_PLATFORM_CODE=ap64
   else
     as_fn_error $? "Unsupported OpenJ9 cpu ${OPENJ9_CPU}, contact support team!" "$LINENO" 5
   fi

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5186,7 +5186,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1506706543
+DATE_WHEN_GENERATED=1507288529
 
 ###############################################################################
 #

--- a/jdk/src/java.base/unix/conf/ppc64/jvm.cfg
+++ b/jdk/src/java.base/unix/conf/ppc64/jvm.cfg
@@ -30,5 +30,8 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
--server KNOWN
--client IGNORE
+-j9vm KNOWN
+-hotspot IGNORE
+-classic IGNORE
+-native IGNORE
+-green IGNORE

--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -310,8 +310,10 @@ MODULE_DEPS_MAKEFILE := $(MAKESUPPORT_OUTPUTDIR)/module-deps.gmk
 
 MODULE_INFOS := $(call FindAllModuleInfos, *)
 
-ifeq ($(TOOLCHAIN_TYPE),microsoft)
+ifeq ($(TOOLCHAIN_TYPE), microsoft)
   CPP_FLAGS_DEPS := -EP -nologo
+else ifeq ($(TOOLCHAIN_TYPE), xlc)
+  CPP_FLAGS_DEPS := -E
 else
   CPP_FLAGS_DEPS := -P - <
 endif


### PR DESCRIPTION
Signed-off-by: Steve Groeger <groeges@uk.ibm.com>

Also requires an OMR change: https://github.com/eclipse/omr/pull/1802 in order to get AIX to build  100% successfully.

Fixes #62