### PR TITLE
Fix Java 18.3 compile/build errors

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -27,7 +27,7 @@ CLEAN_DIRS += vm
 	#
 
 j9vm-build :
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) build-j9)
+	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR) build-j9)
 
 j9vm-compose-buildjvm : j9vm-build $(J9JCL_GENSRC_MAKEFILE)
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)


### PR DESCRIPTION
Fix `Java 18.3` compile/build errors

Pass JCL_LEVEL=$(VERSION_MAJOR) to OpenJ9 makefile.

Closes: eclipse/openj9#293

Reviewer @pshipton 
FYI: @DanHeidinga @adamfarley 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>