### PR TITLE
Clean up openj9 build target dependencies

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -29,7 +29,7 @@ CLEAN_DIRS += vm
 j9vm-build :
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR) build-j9)
 
-j9vm-compose-buildjvm : j9vm-build $(J9JCL_GENSRC_MAKEFILE)
+j9vm-compose-buildjvm : j9vm-build
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)
 
 product-images : openj9-jdk-image openj9-jre-image

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -701,7 +701,7 @@ else
   endif
 
   # Building java.base-jmod requires all of hotspot to be built.
-  java.base-jmod: j9vm-build j9vm-compose-buildjvm 
+  java.base-jmod: j9vm-compose-buildjvm
 
   # Declare dependencies from <module>-jmod to all other module targets
   # When creating a BUILDJDK, the java compilation has already been done by the


### PR DESCRIPTION
Remove obsolete J9JCL_GENSRC_MAKEFILE target
Remove j9vm-build duplicate prerequisite

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>