### PR TITLE
Modify omr and openj9 in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # exclude all source directories
 /build/
-/omr/
-/openj9/
+/omr
+/openj9


### PR DESCRIPTION
Remove trailing slash from /omr and /openj9 in the .gitignore file.
This means that they will be properly ignored when they are not real
folders, but symlinks. Old behaviour still works as expected.

Signed-off-by: Devin Nakamura <dnakamura@ca.ibm.com>