### PR TITLE
Change traceformat makefile to match module rename in OpenJ9

### DIFF
--- a/jdk/make/launcher/Launcher-openj9.traceformat.gmk
+++ b/jdk/make/launcher/Launcher-openj9.traceformat.gmk
@@ -20,7 +20,7 @@
 include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, traceformat, \
-    MAIN_MODULE := com.ibm.traceformat, \
+    MAIN_MODULE := openj9.traceformat, \
     MAIN_CLASS := com.ibm.jvm.traceformat.TraceFormat, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))


### PR DESCRIPTION
Module com.ibm.traceformat renamed to openj9.traceformat in OpenJ9.
Changing filename and text of traceformat makefile to match the change.

Dependent on https://github.com/eclipse/openj9/pull/542

Tested `traceformat` executable locally with changes.

Signed-off-by: mikezhang <mike.h.zhang@ibm.com>