### PR TITLE
Rename runtimes/tr.source to runtimes/compiler

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -304,6 +304,10 @@ $(OUTPUT_ROOT)/vm/util/openj9_version_info.h : \
 	$(foreach var,$(OPENJ9_VERSION_VARS),$(call DependOnVariable, $(var)))
 
 # Only update version files when the SHAs change.
+$(OUTPUT_ROOT)/vm/compiler/jit.version : $(call DependOnVariable, OPENJ9_SHA)
+	@$(MKDIR) -p $(@D)
+	$(ECHO) '#define TR_LEVEL_NAME "$(OPENJ9_SHA)"' > $@
+
 $(OUTPUT_ROOT)/vm/tr.source/jit.version : $(call DependOnVariable, OPENJ9_SHA)
 	@$(MKDIR) -p $(@D)
 	$(ECHO) '#define TR_LEVEL_NAME "$(OPENJ9_SHA)"' > $@
@@ -314,6 +318,7 @@ $(OUTPUT_ROOT)/vm/omr/OMR_VERSION_STRING : $(call DependOnVariable, OPENJ9OMR_SH
 
 run-preprocessors-j9 : stage-j9 \
 		$(OUTPUT_ROOT)/vm/omr/OMR_VERSION_STRING \
+		$(OUTPUT_ROOT)/vm/compiler/jit.version \
 		$(OUTPUT_ROOT)/vm/tr.source/jit.version \
 		$(OUTPUT_ROOT)/vm/util/openj9_version_info.h
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)


### PR DESCRIPTION
We will temporarily generate both version files in tr.source and 
compiler directories to avoid build breaks. A subsequent change will 
remove the tr.source file generation once the dependent builds pickup
this change.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>