### PR TITLE
Changes for ARM cross-compile

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -205,7 +205,12 @@ define openj9_copy_tree_impl
   @$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
 
-$(eval $(call generated_target_rules_build,build_jdk,$(BUILD_JDK)))
+# Temporary fix until we work out how to handle the build_jdk for cross compiles
+ifeq (1,$(OPENJDK_DOCKER_CC_ARM))
+  $(info Cross compilation detected, skipping generated_target_rules_build)
+else
+  $(eval $(call generated_target_rules_build,build_jdk,$(BUILD_JDK)))
+endif
 $(eval $(call generated_target_rules,jdk_image,$(JDK_IMAGE_DIR)))
 $(eval $(call generated_target_rules,jre_image,$(JRE_IMAGE_DIR)))
 

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -152,15 +152,22 @@ AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],
     powerpc64)
       OPENJ9_CPU=ppc-64
       ;;
+    arm)
+      OPENJ9_CPU=arm
+      ;;
     *)
       AC_MSG_ERROR([unsupported OpenJ9 cpu $1])
       ;;
   esac
+  
 ])
 
 AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
 [
-  OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($build_cpu)
+  # When compiling natively host_cpu and build_cpu are the same. But when
+  # cross compiling we need to work with the host_cpu (which is where the final
+  # JVM will run).
+  OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
   OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
 
   if test "x$OPENJ9_CPU" = xx86-64; then
@@ -182,6 +189,9 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64; then
     OPENJ9_PLATFORM_CODE=ap64
+  elif test "x$OPENJ9_CPU" = xarm; then
+    OPENJ9_PLATFORM_CODE=xr32
+    OPENJ9_BUILDSPEC=linux_arm
   else
     AC_MSG_ERROR([Unsupported OpenJ9 cpu ${OPENJ9_CPU}, contact support team!])
   fi

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -30,7 +30,11 @@ j9vm-build :
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR) build-j9)
 
 j9vm-compose-buildjvm : j9vm-build
+ifeq ($(OPENJDK_DOCKER_CC_ARM),1)
+	@$(ECHO) Cross compile detected, skipping stage_openj9_build_jdk
+else
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)
+endif
 
 product-images : openj9-jdk-image openj9-jre-image
 


### PR DESCRIPTION
I divided the changes into two commits. The first deals with updates to custom-hook.m4 to
correctly map the processor name and setup the necessary variables.

The second commit works around a problem with a cross compiled build attempting to overwrite
the given build jvm (with files compiled for the wrong platform).

Signed-off-by: James Kingdon <jkingdon@ca.ibm.com>