### PR TITLE
Support composing 32 bit builds for arm

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -83,6 +83,15 @@ OPENJ9_MISC_FILES := \
 OPENJ9_NOTICE_FILES := openj9-notices.html
 OPENJ9_REDIRECTOR := redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX)
 
+# For arm cross compiles we need some extra libraries defined for use in the generated target rules section.
+# These are libraries that would normally be copied as part of the build jdk rules, but that section is currently
+# not implemented for arm. Once we have a working build jdk as part of the build it will probably be possible
+# to remove these declarations.
+ifeq (xr32,$(OPENJ9_PLATFORM_CODE))
+OPENJ9_JAVA_BASE_LIBRARIES_ARM := $(OPENJ9_JAVA_BASE_LIBRARIES)
+OPENJ9_SHARED_CLASSES_LIBRARIES_ARM := $(OPENJ9_SHARED_CLASSES_LIBRARIES)
+endif
+
 # openjdk makeflags don't work with openj9/omr native compiles; override with number of cpus which openj9 and omr need supplied
 override MAKEFLAGS := -j $(JOBS)
 
@@ -162,21 +171,17 @@ endef
 # ----------------------
 # param 1 = The jdk/jre directory name
 # param 2 = The jdk/jre directory to add openj9 content
-ifeq (xr32,$(OPENJ9_PLATFORM_CODE))
 define generated_target_rules
 .PHONY : stage_openj9_$1
 $(foreach file,$(OPENJ9_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES),$(eval $(call openj9_copy_file,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_NOTICE_FILES),$(eval $(call openj9_copy_file,$2/$(file),$(SRC_ROOT)/$(file))))
 $(foreach file,$(OPENJ9_REDIRECTOR),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
-# Cross compiling for arm doesn't currently build and stage a build jvm, so the mechanism used to
-# install some (but not all) of the libraries in the jdk and jre images doesn't work.
-# Supplement the existing rules with similar ones for the missing libraries
-$(info adding extra libs for arm cross compile)
-$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-stage_openj9_java_base_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES)))
-stage_openj9_shared_classes_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_SHARED_CLASSES_LIBRARIES)))
+# Additional libraries needed when cross compiling for arm because we don't create a build JVM
+$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES_ARM),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES_ARM),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+stage_openj9_java_base_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES_ARM)))
+stage_openj9_shared_classes_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_SHARED_CLASSES_LIBRARIES_ARM)))
 stage_openj9_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_SHARED_LIBRARIES))
 stage_openj9_misc_files_$1 := $(addprefix $2/lib/,$(OPENJ9_MISC_FILES))
 stage_openj9_notice_files_$1 := $(addprefix $2/,$(OPENJ9_NOTICE_FILES))
@@ -191,26 +196,6 @@ stage_openj9_$1 : \
 	$$(stage_openj9_redirector_$1) \
 	$$(stage_openj9_property_files_$1)
 endef
-else	# Not an ARM cross compile
-define generated_target_rules
-.PHONY : stage_openj9_$1
-$(foreach file,$(OPENJ9_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES),$(eval $(call openj9_copy_file,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_NOTICE_FILES),$(eval $(call openj9_copy_file,$2/$(file),$(SRC_ROOT)/$(file))))
-$(foreach file,$(OPENJ9_REDIRECTOR),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
-stage_openj9_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_SHARED_LIBRARIES))
-stage_openj9_misc_files_$1 := $(addprefix $2/lib/,$(OPENJ9_MISC_FILES))
-stage_openj9_notice_files_$1 := $(addprefix $2/,$(OPENJ9_NOTICE_FILES))
-stage_openj9_property_files_$1 := $(addprefix $2/lib/,$(OPENJ9_PROPERTY_FILES))
-stage_openj9_redirector_$1 := $2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
-stage_openj9_$1 : \
-	$$(stage_openj9_shared_libraries_$1) \
-	$$(stage_openj9_misc_files_$1) \
-	$$(stage_openj9_notice_files_$1) \
-	$$(stage_openj9_redirector_$1) \
-	$$(stage_openj9_property_files_$1)
-endef
-endif
 
 # openj9_copy_file
 # ----------------

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -127,24 +127,24 @@ endif
 # param 2 = The jdk/jre directory to add openj9 content
 define generated_target_rules_build
 .PHONY : stage_openj9_$1
-$(foreach file,$(OPENJ9_BUILD_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/compressedrefs/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_ALT_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/compressedrefs/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_BUILD_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_ALT_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES),$(eval $(call openj9_copy_file,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_NOTICE_FILES),$(eval $(call openj9_copy_file,$2/$(file),$(SRC_ROOT)/$(file))))
 $(foreach file,$(OPENJ9_REDIRECTOR),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES),$(eval $(call openj9_copy_file,$(OUTPUT_ROOT)/support/modules_libs/java.base/compressedrefs/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES),$(eval $(call openj9_copy_file,$(OUTPUT_ROOT)/support/modules_libs/openj9.sharedclasses/compressedrefs/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_MANAGEMENT_LIBRARIES),$(eval $(call openj9_copy_file,$(OUTPUT_ROOT)/support/modules_libs/java.management/compressedrefs/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES),$(eval $(call openj9_copy_file,$(OUTPUT_ROOT)/support/modules_libs/java.base/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES),$(eval $(call openj9_copy_file,$(OUTPUT_ROOT)/support/modules_libs/openj9.sharedclasses/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_MANAGEMENT_LIBRARIES),$(eval $(call openj9_copy_file,$(OUTPUT_ROOT)/support/modules_libs/java.management/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
 
-stage_openj9_build_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/compressedrefs/,$(OPENJ9_BUILD_LIBRARIES))
-stage_openj9_alt_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/compressedrefs/,$(notdir $(OPENJ9_ALT_SHARED_LIBRARIES)))
+stage_openj9_build_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_BUILD_LIBRARIES))
+stage_openj9_alt_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_ALT_SHARED_LIBRARIES)))
 stage_openj9_misc_files_$1 := $(addprefix $2/lib/,$(OPENJ9_MISC_FILES))
 stage_openj9_notice_files_$1 := $(addprefix $2/,$(OPENJ9_NOTICE_FILES))
 stage_openj9_property_files_$1 := $(addprefix $2/lib/,$(OPENJ9_PROPERTY_FILES))
 stage_openj9_redirector_$1 := $2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
-stage_openj9_java_base_build_modules := $(addprefix $(OUTPUT_ROOT)/support/modules_libs/java.base/compressedrefs/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES)))
-stage_openj9_shared_classes_build_modules := $(addprefix $(OUTPUT_ROOT)/support/modules_libs/openj9.sharedclasses/compressedrefs/,$(OPENJ9_SHARED_CLASSES_LIBRARIES))
-stage_openj9_management_modules := $(addprefix $(OUTPUT_ROOT)/support/modules_libs/java.management/compressedrefs/,$(notdir $(OPENJ9_MANAGEMENT_LIBRARIES)))
+stage_openj9_java_base_build_modules := $(addprefix $(OUTPUT_ROOT)/support/modules_libs/java.base/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES)))
+stage_openj9_shared_classes_build_modules := $(addprefix $(OUTPUT_ROOT)/support/modules_libs/openj9.sharedclasses/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_SHARED_CLASSES_LIBRARIES))
+stage_openj9_management_modules := $(addprefix $(OUTPUT_ROOT)/support/modules_libs/java.management/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_MANAGEMENT_LIBRARIES)))
 
 stage_openj9_$1 : \
         $$(stage_openj9_build_libraries_$1) \
@@ -162,13 +162,43 @@ endef
 # ----------------------
 # param 1 = The jdk/jre directory name
 # param 2 = The jdk/jre directory to add openj9 content
+ifeq (xr32,$(OPENJ9_PLATFORM_CODE))
 define generated_target_rules
 .PHONY : stage_openj9_$1
-$(foreach file,$(OPENJ9_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/compressedrefs/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES),$(eval $(call openj9_copy_file,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_NOTICE_FILES),$(eval $(call openj9_copy_file,$2/$(file),$(SRC_ROOT)/$(file))))
 $(foreach file,$(OPENJ9_REDIRECTOR),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
-stage_openj9_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/compressedrefs/,$(OPENJ9_SHARED_LIBRARIES))
+# Cross compiling for arm doesn't currently build and stage a build jvm, so the mechanism used to
+# install some (but not all) of the libraries in the jdk and jre images doesn't work.
+# Supplement the existing rules with similar ones for the missing libraries
+$(info adding extra libs for arm cross compile)
+$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+stage_openj9_java_base_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES)))
+stage_openj9_shared_classes_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_SHARED_CLASSES_LIBRARIES)))
+stage_openj9_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_SHARED_LIBRARIES))
+stage_openj9_misc_files_$1 := $(addprefix $2/lib/,$(OPENJ9_MISC_FILES))
+stage_openj9_notice_files_$1 := $(addprefix $2/,$(OPENJ9_NOTICE_FILES))
+stage_openj9_property_files_$1 := $(addprefix $2/lib/,$(OPENJ9_PROPERTY_FILES))
+stage_openj9_redirector_$1 := $2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
+stage_openj9_$1 : \
+	$$(stage_openj9_java_base_libraries_$1) \
+	$$(stage_openj9_shared_classes_libraries_$1) \
+	$$(stage_openj9_shared_libraries_$1) \
+	$$(stage_openj9_misc_files_$1) \
+	$$(stage_openj9_notice_files_$1) \
+	$$(stage_openj9_redirector_$1) \
+	$$(stage_openj9_property_files_$1)
+endef
+else	# Not an ARM cross compile
+define generated_target_rules
+.PHONY : stage_openj9_$1
+$(foreach file,$(OPENJ9_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES),$(eval $(call openj9_copy_file,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_NOTICE_FILES),$(eval $(call openj9_copy_file,$2/$(file),$(SRC_ROOT)/$(file))))
+$(foreach file,$(OPENJ9_REDIRECTOR),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
+stage_openj9_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_SHARED_LIBRARIES))
 stage_openj9_misc_files_$1 := $(addprefix $2/lib/,$(OPENJ9_MISC_FILES))
 stage_openj9_notice_files_$1 := $(addprefix $2/,$(OPENJ9_NOTICE_FILES))
 stage_openj9_property_files_$1 := $(addprefix $2/lib/,$(OPENJ9_PROPERTY_FILES))
@@ -180,6 +210,7 @@ stage_openj9_$1 : \
 	$$(stage_openj9_redirector_$1) \
 	$$(stage_openj9_property_files_$1)
 endef
+endif
 
 # openj9_copy_file
 # ----------------
@@ -208,7 +239,12 @@ define openj9_copy_tree_impl
   @$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
 
-$(eval $(call generated_target_rules_build,build_jdk,$(BUILD_JDK)))
+# Temporary fix until we work out how to handle the build_jdk for cross compiles
+ifeq (xr32,$(OPENJ9_PLATFORM_CODE))
+  $(info Cross compilation detected, skipping generated_target_rules_build)
+else
+  $(eval $(call generated_target_rules_build,build_jdk,$(BUILD_JDK)))
+endif
 $(eval $(call generated_target_rules,jdk_image,$(JDK_IMAGE_DIR)))
 $(eval $(call generated_target_rules,jre_image,$(JRE_IMAGE_DIR)))
 

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -83,13 +83,13 @@ OPENJ9_MISC_FILES := \
 OPENJ9_NOTICE_FILES := openj9-notices.html
 OPENJ9_REDIRECTOR := redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX)
 
-# For arm cross compiles we need some extra libraries defined for use in the generated target rules section.
+# For cross compiles we need some extra libraries defined for use in the generated target rules section.
 # These are libraries that would normally be copied as part of the build jdk rules, but that section is currently
-# not implemented for arm. Once we have a working build jdk as part of the build it will probably be possible
+# not active during cross compilation. Once we have a working build jdk as part of the build it will probably be possible
 # to remove these declarations.
-ifeq (xr32,$(OPENJ9_PLATFORM_CODE))
-OPENJ9_JAVA_BASE_LIBRARIES_ARM := $(OPENJ9_JAVA_BASE_LIBRARIES)
-OPENJ9_SHARED_CLASSES_LIBRARIES_ARM := $(OPENJ9_SHARED_CLASSES_LIBRARIES)
+ifneq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
+OPENJ9_JAVA_BASE_LIBRARIES_CROSS := $(OPENJ9_JAVA_BASE_LIBRARIES)
+OPENJ9_SHARED_CLASSES_LIBRARIES_CROSS := $(OPENJ9_SHARED_CLASSES_LIBRARIES)
 endif
 
 # openjdk makeflags don't work with openj9/omr native compiles; override with number of cpus which openj9 and omr need supplied
@@ -177,11 +177,11 @@ $(foreach file,$(OPENJ9_SHARED_LIBRARIES),$(eval $(call openj9_copy_file,$2/$(OP
 $(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES),$(eval $(call openj9_copy_file,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 $(foreach file,$(OPENJ9_NOTICE_FILES),$(eval $(call openj9_copy_file,$2/$(file),$(SRC_ROOT)/$(file))))
 $(foreach file,$(OPENJ9_REDIRECTOR),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
-# Additional libraries needed when cross compiling for arm because we don't create a build JVM
-$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES_ARM),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES_ARM),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
-stage_openj9_java_base_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES_ARM)))
-stage_openj9_shared_classes_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_SHARED_CLASSES_LIBRARIES_ARM)))
+# Additional libraries needed when cross compiling because we don't create a build JVM
+$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES_CROSS),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES_CROSS),$(eval $(call openj9_copy_file,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+stage_openj9_java_base_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_JAVA_BASE_LIBRARIES_CROSS)))
+stage_openj9_shared_classes_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(notdir $(OPENJ9_SHARED_CLASSES_LIBRARIES_CROSS)))
 stage_openj9_shared_libraries_$1 := $(addprefix $2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/,$(OPENJ9_SHARED_LIBRARIES))
 stage_openj9_misc_files_$1 := $(addprefix $2/lib/,$(OPENJ9_MISC_FILES))
 stage_openj9_notice_files_$1 := $(addprefix $2/,$(OPENJ9_NOTICE_FILES))
@@ -225,7 +225,7 @@ define openj9_copy_tree_impl
 endef
 
 # Temporary fix until we work out how to handle the build_jdk for cross compiles
-ifeq (xr32,$(OPENJ9_PLATFORM_CODE))
+ifneq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
   $(info Cross compilation detected, skipping generated_target_rules_build)
 else
   $(eval $(call generated_target_rules_build,build_jdk,$(BUILD_JDK)))

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -152,16 +152,24 @@ AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],
     powerpc64)
       OPENJ9_CPU=ppc-64
       ;;
+    arm)
+      OPENJ9_CPU=arm
+      ;;
     *)
       AC_MSG_ERROR([unsupported OpenJ9 cpu $1])
       ;;
   esac
+  
 ])
 
 AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
 [
-  OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($build_cpu)
+  # When compiling natively host_cpu and build_cpu are the same. But when
+  # cross compiling we need to work with the host_cpu (which is where the final
+  # JVM will run).
+  OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
   OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
+  OPENJ9_LIBS_SUBDIR=compressedrefs
 
   if test "x$OPENJ9_CPU" = xx86-64; then
     if test "x$OPENJDK_BUILD_OS" = xlinux; then
@@ -182,6 +190,10 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64; then
     OPENJ9_PLATFORM_CODE=ap64
+  elif test "x$OPENJ9_CPU" = xarm; then
+    OPENJ9_PLATFORM_CODE=xr32
+    OPENJ9_BUILDSPEC=linux_arm_linaro
+    OPENJ9_LIBS_SUBDIR=default
   else
     AC_MSG_ERROR([Unsupported OpenJ9 cpu ${OPENJ9_CPU}, contact support team!])
   fi
@@ -189,6 +201,7 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
   AC_SUBST(OPENJ9_BUILDSPEC)
   AC_SUBST(OPENJ9_PLATFORM_CODE)
   AC_SUBST(COMPILER_VERSION_STRING)
+  AC_SUBST(OPENJ9_LIBS_SUBDIR)
 ])
 
 AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -61,6 +61,8 @@ OPENJ9_BUILDSPEC        := @OPENJ9_BUILDSPEC@
 # required by JPP
 OPENJ9_PLATFORM_CODE    := @OPENJ9_PLATFORM_CODE@
 
+OPENJ9_LIBS_SUBDIR      := @OPENJ9_LIBS_SUBDIR@
+
 ifeq ($(OPENJDK_TARGET_OS), windows)
   # Set environment variables for Microsoft Visual Studio toolchain.
   # Note that PATH is set in spec.gmk.

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -970,6 +970,7 @@ OPENJ9_ENABLE_CMAKE
 CMAKE
 OPENJDK_TAG
 OPENJDK_SHA
+OPENJ9_LIBS_SUBDIR
 COMPILER_VERSION_STRING
 OPENJ9_PLATFORM_CODE
 OPENJ9_BUILDSPEC
@@ -1114,6 +1115,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1411,6 +1413,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1663,6 +1666,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1800,7 +1812,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1953,6 +1965,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -5251,7 +5264,11 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
+<<<<<<< a41d5ef5633e6f6ffc637fe350cd883dea93fb9b
 DATE_WHEN_GENERATED=1515058356
+=======
+DATE_WHEN_GENERATED=1512647666
+>>>>>>> Enable cross-compile for armhf
 
 ###############################################################################
 #
@@ -17114,9 +17131,12 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
 
 # With basic setup done, call the custom early hook.
 
+  # When compiling natively host_cpu and build_cpu are the same. But when
+  # cross compiling we need to work with the host_cpu (which is where the final
+  # JVM will run).
 
   # Convert openjdk cpu names to openj9 names
-  case "$build_cpu" in
+  case "$host_cpu" in
     x86_64)
       OPENJ9_CPU=x86-64
       ;;
@@ -17129,12 +17149,17 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
     powerpc64)
       OPENJ9_CPU=ppc-64
       ;;
+    arm)
+      OPENJ9_CPU=arm
+      ;;
     *)
-      as_fn_error $? "unsupported OpenJ9 cpu $build_cpu" "$LINENO" 5
+      as_fn_error $? "unsupported OpenJ9 cpu $host_cpu" "$LINENO" 5
       ;;
   esac
 
+
   OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
+  OPENJ9_LIBS_SUBDIR=compressedrefs
 
   if test "x$OPENJ9_CPU" = xx86-64; then
     if test "x$OPENJDK_BUILD_OS" = xlinux; then
@@ -17155,9 +17180,14 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64; then
     OPENJ9_PLATFORM_CODE=ap64
+  elif test "x$OPENJ9_CPU" = xarm; then
+    OPENJ9_PLATFORM_CODE=xr32
+    OPENJ9_BUILDSPEC=linux_arm_linaro
+    OPENJ9_LIBS_SUBDIR=default
   else
     as_fn_error $? "Unsupported OpenJ9 cpu ${OPENJ9_CPU}, contact support team!" "$LINENO" 5
   fi
+
 
 
 

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -5264,11 +5264,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-<<<<<<< a41d5ef5633e6f6ffc637fe350cd883dea93fb9b
-DATE_WHEN_GENERATED=1515058356
-=======
-DATE_WHEN_GENERATED=1512647666
->>>>>>> Enable cross-compile for armhf
+DATE_WHEN_GENERATED=1517096419
 
 ###############################################################################
 #

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -30,7 +30,11 @@ j9vm-build :
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR) build-j9)
 
 j9vm-compose-buildjvm : j9vm-build
+ifeq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)
+else
+	@$(ECHO) Cross compile detected, skipping stage_openj9_build_jdk
+endif
 
 product-images : openj9-jdk-image openj9-jre-image
 

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -1100,6 +1100,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1391,6 +1392,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1643,6 +1645,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1780,7 +1791,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1933,6 +1944,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -5186,7 +5198,11 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
+<<<<<<< a41d5ef5633e6f6ffc637fe350cd883dea93fb9b
 DATE_WHEN_GENERATED=1515058356
+=======
+DATE_WHEN_GENERATED=1512647666
+>>>>>>> Enable cross-compile for armhf
 
 ###############################################################################
 #

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5198,11 +5198,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-<<<<<<< a41d5ef5633e6f6ffc637fe350cd883dea93fb9b
-DATE_WHEN_GENERATED=1515058356
-=======
-DATE_WHEN_GENERATED=1512647666
->>>>>>> Enable cross-compile for armhf
+DATE_WHEN_GENERATED=1517096419
 
 ###############################################################################
 #


### PR DESCRIPTION
With all the review changes the previous PR became obsolete. This PR now covers all the changes required (in this project) for a working 32 bit cross compile hosted on x86 and targeting armhf.