### PR TITLE
Apply OpenJDK10 change to get AIX JRE image to be built

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -434,8 +434,8 @@ $(eval $(call IncludeCustomExtension, , Images-post.gmk))
 $(JRE_TARGETS): $(TOOL_JRE_TARGETS)
 $(JDK_TARGETS): $(TOOL_JDK_TARGETS)
 
-jdk: $(JDK_TARGETS)
-jre: $(JRE_TARGETS)
+jdk: $(TOOL_JDK_TARGETS) $(JDK_TARGETS)
+jre: $(TOOL_JRE_TARGETS) $(JRE_TARGETS)
 symbols: $(SYMBOLS_TARGETS)
 
 all: jdk jre symbols


### PR DESCRIPTION
Backporting of fix from OpenJDK10 onto JDK9 Extensions
http://hg.openjdk.java.net/jdk10/master/rev/7a7bc84f4b6c

Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>