### PR TITLE
Rename dtfjview makefile to match module rename in OpenJ9

### DIFF
--- a/jdk/make/launcher/Launcher-openj9.dtfjview.gmk
+++ b/jdk/make/launcher/Launcher-openj9.dtfjview.gmk
@@ -4,7 +4,7 @@
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -14,13 +14,13 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
+#
 # ===========================================================================
 
 include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jdmpview, \
-    MAIN_MODULE := com.ibm.dtfjview, \
+    MAIN_MODULE := openj9.dtfjview, \
     MAIN_CLASS := com.ibm.jvm.dtfjview.DTFJView, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))


### PR DESCRIPTION
Depends on https://github.com/eclipse/openj9/pull/703

Signed-off-by: mikezhang <mike.h.zhang@ibm.com>