### PR TITLE
fix OPENJDK_TAG in java version output

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -195,6 +195,12 @@ AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
 [
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
   OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${OPENJDK_SHA}"`
+
+  if test "x$OPENJDK_TAG" = x; then
+    LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${LAST_TAGGED_REVISION}"`
+  fi
+
   AC_SUBST(OPENJDK_SHA)
   AC_SUBST(OPENJDK_TAG)
 ])

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -5251,7 +5251,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1512490616
+DATE_WHEN_GENERATED=1515058356
 
 ###############################################################################
 #
@@ -17166,6 +17166,12 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
 
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
   OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${OPENJDK_SHA}"`
+
+  if test "x$OPENJDK_TAG" = x; then
+    LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${LAST_TAGGED_REVISION}"`
+  fi
+
 
 
 

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5186,7 +5186,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1512490616
+DATE_WHEN_GENERATED=1515058356
 
 ###############################################################################
 #


### PR DESCRIPTION
fix for #93. If tag for current revision is not available, take it last tag added in repo.

java -version output before fix

```
openjdk version "9-internal"
OpenJDK Runtime Environment (build 9-internal+0-adhoc.jenkins.openjdk)
Eclipse OpenJ9 VM (build 2.9, JRE 9 Linux amd64-64 Compressed References 20180102_81 (JIT enabled, AOT enabled)
OpenJ9   - 2df6261
OMR      - 25bb9f4
OpenJDK  - f1a22d1 based on )
```

java -version output after fix 

```
openjdk version "9-internal"
OpenJDK Runtime Environment (build 9-internal+0-adhoc.bhamaram.openjdk)
Eclipse OpenJ9 VM (build 2.9, JRE 9 Linux amd64-64 Compressed References 20180104_000000 (JIT enabled, AOT enabled)
OpenJ9   - 4cc5b0a
OMR      - 66568c6
OpenJDK  - f1a22d1 based on jdk-9+181)
```