### PR TITLE
Undo JLink Module Extensions

### DIFF
--- a/jdk/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
+++ b/jdk/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
@@ -1,10 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2016, 2017 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -108,7 +102,7 @@ public final class GenerateJLIClassesPlugin implements Plugin {
 
     @Override
     public Set<State> getState() {
-        return EnumSet.of(State.DISABLED, State.FUNCTIONAL);
+        return EnumSet.of(State.AUTO_ENABLED, State.FUNCTIONAL);
     }
 
     @Override

--- a/jdk/src/jdk.jlink/share/classes/module-info.java
+++ b/jdk/src/jdk.jlink/share/classes/module-info.java
@@ -1,10 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2015, 2017 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -81,6 +75,7 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.DefaultCompressPlugin,
         jdk.tools.jlink.internal.plugins.ExcludeVMPlugin,
         jdk.tools.jlink.internal.plugins.IncludeLocalesPlugin,
+        jdk.tools.jlink.internal.plugins.GenerateJLIClassesPlugin,
         jdk.tools.jlink.internal.plugins.ReleaseInfoPlugin,
         jdk.tools.jlink.internal.plugins.ClassForNamePlugin;
  }


### PR DESCRIPTION
We don't need them any more, as patches have been made to OpenJ9 to
compensate for their absence.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>