### PR TITLE
Remove constants that the user should set themselves

### DIFF
--- a/closed/openj9_version_info.h.in
+++ b/closed/openj9_version_info.h.in
@@ -30,7 +30,5 @@
 #define J9VERSION_STRING          "@VERSION_STRING@"
 #define OPENJDK_SHA               "@OPENJDK_SHA@"
 #define OPENJDK_TAG               "@OPENJDK_TAG@"
-#define VENDOR_SHORT_NAME         "OpenJDK"
-#define VENDOR_SHA                "@OPENJDK_SHA@ based on @OPENJDK_TAG@"
 
 #endif /* OPENJ9_VERSION_INFO_H */


### PR DESCRIPTION
The vendor constants should be set by the vendor (user) at build 
time. Setting it internally only complicates things later, so we 
will remove these definitions here, and compensate in OpenJ9.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>