### PR TITLE
Remove OpenJDK SHA add-on code for extensions

### DIFF
--- a/jdk/make/gensrc/GensrcMisc.gmk
+++ b/jdk/make/gensrc/GensrcMisc.gmk
@@ -1,6 +1,4 @@
 #
-# (c) Copyright IBM Corp. 2011, 2017 All Rights Reserved
-#
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -28,6 +26,7 @@
 ################################################################################
 # Install the launcher name, release version string, full version
 # string and the runtime name into the VersionProps.java file.
+
 $(eval $(call SetupTextFileProcessing, BUILD_VERSION_JAVA, \
     SOURCE_FILES := $(JDK_TOPDIR)/src/java.base/share/classes/java/lang/VersionProps.java.template, \
     OUTPUT_FILE := $(SUPPORT_OUTPUTDIR)/gensrc/java.base/java/lang/VersionProps.java, \
@@ -39,9 +38,7 @@ $(eval $(call SetupTextFileProcessing, BUILD_VERSION_JAVA, \
         @@VERSION_NUMBER@@ => $(VERSION_NUMBER) ; \
         @@VERSION_PRE@@ => $(VERSION_PRE) ; \
         @@VERSION_BUILD@@ => $(VERSION_BUILD) ; \
-        @@VERSION_OPT@@ => $(VERSION_OPT) ; \
-        @@OPENJDK_SHA@@ => $(OPENJDK_SHA) ; \
-        @@OPENJDK_TAG@@ => $(OPENJDK_TAG), \
+        @@VERSION_OPT@@ => $(VERSION_OPT) , \
 ))
 
 GENSRC_JAVA_BASE += $(BUILD_VERSION_JAVA)

--- a/jdk/src/java.base/share/classes/java/lang/VersionProps.java.template
+++ b/jdk/src/java.base/share/classes/java/lang/VersionProps.java.template
@@ -1,10 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 1999, 2017 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,12 +38,6 @@ class VersionProps {
 
     private static final String java_version =
         "@@VERSION_SHORT@@";
-
-    private static final String openjdk_sha =
-        "@@OPENJDK_SHA@@";
-
-    private static final String openjdk_tag =
-        "@@OPENJDK_TAG@@";
 
     private static final String java_runtime_name =
         "@@RUNTIME_NAME@@";
@@ -198,7 +186,7 @@ class VersionProps {
         String java_vm_version = System.getProperty("java.vm.version");
         String java_vm_info    = System.getProperty("java.vm.info");
         ps.println(java_vm_name + " (" + jdk_debug_level + "build " + java_vm_version + ", " +
-                   java_vm_info + "\nOpenJDK  - " + openjdk_sha + " based on " + openjdk_tag + ")");
+                   java_vm_info + ")");
     }
 
 }


### PR DESCRIPTION
Extensions used to add the OpenJDK SHA to the java -version
output.

Now OpenJ9 does it in eclipse/openj9#1010, so this code isn't needed anymore.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>