### PR TITLE
Exclude optional eclipse project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /build/
 /omr
 /openj9
+# exclude optional eclipse project file
+/.project


### PR DESCRIPTION
If the user turns their local clone into a git project, this
ignore prevents them accidentally committing their project file
into the git repository.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>