### PR TITLE
Undo all changes for OpenJ9

### DIFF
--- a/jdk/make/gensrc/GensrcMisc.gmk
+++ b/jdk/make/gensrc/GensrcMisc.gmk
@@ -38,7 +38,7 @@ $(eval $(call SetupTextFileProcessing, BUILD_VERSION_JAVA, \
         @@VERSION_NUMBER@@ => $(VERSION_NUMBER) ; \
         @@VERSION_PRE@@ => $(VERSION_PRE) ; \
         @@VERSION_BUILD@@ => $(VERSION_BUILD) ; \
-        @@VERSION_OPT@@ => $(VERSION_OPT) , \
+        @@VERSION_OPT@@ => $(VERSION_OPT), \
 ))
 
 GENSRC_JAVA_BASE += $(BUILD_VERSION_JAVA)


### PR DESCRIPTION
Remove a space which was the only difference relative to OpenJDK.