### PR TITLE
Remove GenModuleInfoSource Extension

### DIFF
--- a/jdk/make/src/classes/build/tools/module/GenModuleInfoSource.java
+++ b/jdk/make/src/classes/build/tools/module/GenModuleInfoSource.java
@@ -1,10 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2015, 2017 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -162,12 +156,12 @@ public class GenModuleInfoSource {
             }
 
             // requires
-            //for (String l : lines) {
-            //    if (l.trim().startsWith("requires"))
-            //        writer.println(l);
-            //}
+            for (String l : lines) {
+                if (l.trim().startsWith("requires"))
+                    writer.println(l);
+            }
 
-            // write requires, exports, opens, uses, and provides
+            // write exports, opens, uses, and provides
             moduleInfo.print(writer);
 
             // close
@@ -177,13 +171,12 @@ public class GenModuleInfoSource {
 
 
     class ModuleInfo {
-        final Map<String, Statement> requires = new HashMap<>();
         final Map<String, Statement> exports = new HashMap<>();
         final Map<String, Statement> opens = new HashMap<>();
         final Map<String, Statement> uses = new HashMap<>();
         final Map<String, Statement> provides = new HashMap<>();
 
-        Statement getStatement(String directive, String qualifier, String name) {
+        Statement getStatement(String directive, String name) {
             switch (directive) {
                 case "exports":
                     if (moduleInfo.exports.containsKey(name) &&
@@ -211,10 +204,6 @@ public class GenModuleInfoSource {
                 case "uses":
                     return uses.computeIfAbsent(name,
                         _n -> new Statement("uses", "", name));
-
-                case "requires":
-                    return uses.computeIfAbsent(name,
-                        _n -> new Statement("requires", qualifier, name));
 
                 case "provides":
                     return provides.computeIfAbsent(name,
@@ -244,7 +233,7 @@ public class GenModuleInfoSource {
                 .stream()
                 .filter(e -> !exports.containsKey(e.getKey()) &&
                                 e.getValue().filter(modules))
-                .forEach(e -> addTargets(getStatement("exports", null, e.getKey()),
+                .forEach(e -> addTargets(getStatement("exports", e.getKey()),
                                          e.getValue(),
                                          modules));
 
@@ -262,7 +251,7 @@ public class GenModuleInfoSource {
                 .stream()
                 .filter(e -> !opens.containsKey(e.getKey()) &&
                                 e.getValue().filter(modules))
-                .forEach(e -> addTargets(getStatement("opens", null, e.getKey()),
+                .forEach(e -> addTargets(getStatement("opens", e.getKey()),
                                          e.getValue(),
                                          modules));
 
@@ -283,12 +272,6 @@ public class GenModuleInfoSource {
                 .stream()
                 .filter(service -> !uses.containsKey(service))
                 .forEach(service -> uses.put(service, extraFiles.uses.get(service)));
-
-            // requires
-            extraFiles.requires.keySet()
-                .stream()
-                .filter(require -> !requires.containsKey(require))
-                .forEach(require -> requires.put(require, extraFiles.requires.get(require)));
         }
 
         // add qualified exports or opens to known modules only
@@ -341,11 +324,6 @@ public class GenModuleInfoSource {
 
 
         void print(PrintWriter writer) {
-            // requires
-            requires.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .forEach(e -> writer.println(e.getValue()));
-
             // print unqualified exports
             exports.entrySet().stream()
                 .filter(e -> e.getValue().targets.isEmpty())
@@ -440,45 +418,27 @@ public class GenModuleInfoSource {
                     String keyword = s[0].trim();
 
                     String name = s.length > 1 ? s[1].trim() : null;
-                    String requiresModifiedName1 = s.length > 2 ? s[2].trim() : null;
-                    String requiresModifiedName2 = s.length > 3 ? s[3].trim() : null;
                     trace("%d: %s index=%d len=%d%n", lineNumber, l, index, l.length());
                     switch (keyword) {
                         case "module":
+                        case "requires":
                         case "}":
                             index = l.length();  // skip to the end
                             continue;
 
-                        case "requires":
                         case "exports":
                         case "opens":
                         case "provides":
                         case "uses":
-                            String requiresQualifier = null;
                             // assume name immediately after exports, opens, provides, uses
-                            if (keyword.equals("requires")) {
-                               if (requiresModifiedName2 != null) { // 2 modifiers specified
-                                   if ((name.equals("transitive") || name.equals("static")) &&
-                                       (requiresModifiedName1.equals("transitive") || requiresModifiedName1.equals("static"))) {
-                                       requiresQualifier = "static transitive";
-                                       name = requiresModifiedName2;
-                                   }
-                               } else if (requiresModifiedName1 != null) { // 1 modifier specified
-                                   if (name.equals("transitive") || name.equals("static")) {
-                                       requiresQualifier = name;
-                                       name = requiresModifiedName1;
-                                   }
-                               }
-                            }
-
-                            statement = getStatement(keyword, requiresQualifier, name);
+                            statement = getStatement(keyword, name);
                             hasTargets = false;
 
                             int i = l.indexOf(name, keyword.length()+1) + name.length() + 1;
                             l = i < l.length() ? l.substring(i, l.length()).trim() : "";
                             index = 0;
 
-                            if (!keyword.equals("requires") && s.length >= 3) {
+                            if (s.length >= 3) {
                                 if (!s[2].trim().equals(statement.qualifier)) {
                                     throw new RuntimeException(sourcefile + ", line " +
                                         lineNumber + ", is malformed: " + s[2]);
@@ -634,25 +594,17 @@ public class GenModuleInfoSource {
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder("    ");
-            if (directive.equals("requires")) {
-               if (qualifier != null) {
-                  sb.append(directive).append(" ").append(qualifier).append(" ").append(name).append(";");
-               } else {
-                  sb.append(directive).append(" ").append(name).append(";");
-               }
+            sb.append(directive).append(" ").append(name);
+            if (targets.isEmpty()) {
+                sb.append(";");
+            } else if (targets.size() == 1) {
+                sb.append(" ").append(qualifier)
+                  .append(orderedTargets().collect(joining(",", " ", ";")));
             } else {
-               sb.append(directive).append(" ").append(name);
-               if (targets.isEmpty()) {
-                   sb.append(";");
-               } else if (targets.size() == 1) {
-                   sb.append(" ").append(qualifier)
-                     .append(orderedTargets().collect(joining(",", " ", ";")));
-               } else {
-                   sb.append(" ").append(qualifier)
-                     .append(orderedTargets()
-                         .map(target -> String.format("        %s", target))
-                         .collect(joining(",\n", "\n", ";")));
-               }
+                sb.append(" ").append(qualifier)
+                  .append(orderedTargets()
+                      .map(target -> String.format("        %s", target))
+                      .collect(joining(",\n", "\n", ";")));
             }
             return sb.toString();
         }


### PR DESCRIPTION
This extension allows the user to use "requires" lines in
their module-info.java.extra files. This functionality is
only required because the OpenJ9 VM needed to add a
"requires" that is unique to that VM. Now it doesn't need
it anymore, we can remove this extension.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>