### PR TITLE
Checkout branch/sha to keep branch info

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -178,7 +178,7 @@ for i in "${!git_urls[@]}" ; do
 		echo
 
 		cd ${i}
-		git checkout ${shas[$i]}
+		git checkout -B ${branches[$i]} ${shas[$i]}
 		cd - > /dev/null
 	fi
 done


### PR DESCRIPTION
Checkout `branch/sha` to keep `branch` info

Closes: https://github.com/eclipse/openj9/issues/1149

Reviewer @Peter-Shipton 
FYI: @daniel-heidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>