### PR TITLE
Removed an obsolete OpenJ9 jcl preprocessor configuration

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -416,7 +416,7 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 		com.ibm.jpp.commandline.CommandlineBuilder \
 			-verdict \
 			-baseDir "$(JPP_BASE_DIR)/" \
-			-config SIDECAR19-SE-B175 \
+			-config SIDECAR19-SE-OPENJ9 \
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(JPP_DEST)" \


### PR DESCRIPTION
SIDECAR19-SE-B175 is replaced by SIDECAR19-SE-OPENJ9.
Depends on eclipse/openj9#1178

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>