### PR TITLE
Remove superfluous copyright

### DIFF
--- a/jdk/src/java.base/share/classes/java/nio/Bits.java
+++ b/jdk/src/java.base/share/classes/java/nio/Bits.java
@@ -1,10 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2000, 2018 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -96,7 +90,7 @@ class Bits {                            // package-private
     static int pageCount(long size) {
         return (int)(size + (long)pageSize() - 1L) / pageSize();
     }
-    
+
     private static boolean unaligned = unsafe.unalignedAccess();
 
     static boolean unaligned() {


### PR DESCRIPTION
There are no extensions in this file, and therefore an IBM copyright
notice is superfluous. Removing.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>