### PR TITLE
Move Shared classes module info extension into closed

### DIFF
--- a/closed/src/java.rmi/share/classes/module-info.java.extra
+++ b/closed/src/java.rmi/share/classes/module-info.java.extra
@@ -1,0 +1,25 @@
+/*[INCLUDE-IF Sidecar19-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+module java.rmi {
+  uses com.ibm.sharedclasses.spi.SharedClassProvider;
+}

--- a/jdk/src/java.rmi/share/classes/module-info.java
+++ b/jdk/src/java.rmi/share/classes/module-info.java
@@ -1,10 +1,4 @@
 /*
-* ===========================================================================
-* (c) Copyright IBM Corp. 2014, 2017 All Rights Reserved
-* ===========================================================================
-*/
-
-/*
  * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,6 +69,4 @@ module java.rmi {
         jdk.jconsole;
 
     uses java.rmi.server.RMIClassLoaderSpi;
-    uses com.ibm.sharedclasses.spi.SharedClassProvider;
-    
 }


### PR DESCRIPTION
Open extensions have to be merged with a copy of OpenJDK,
which is undesirable because it leads to merge conflicts
and release delays. Closed extensions don't have this
problem, so I'm putting this extension into closed.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>