### PR TITLE
Undo DBB extensions to Unsafe.java

### DIFF
--- a/jdk/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jdk/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1,10 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2000, 2017 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -637,25 +631,6 @@ public final class Unsafe {
         checkSize(bytes);
     }
 
-     /**
-      * Allocates a new block of native memory for DirectByteBuffers, of the
-      * given size in bytes.  The contents of the memory are uninitialized;
-      * they will generally be garbage.  The resulting native pointer will
-      * never be zero, and will be aligned for all value types.  Dispose of
-      * this memory by calling {@link #freeDBBMemory} or resize it with
-      * {@link #reallocateDBBMemory}.
-      *
-      * @throws IllegalArgumentException if the size is negative or too large
-      *         for the native size_t type
-      *
-      * @throws OutOfMemoryError if the allocation is refused by the system
-      *
-      * @see #getByte(long)
-      * @see #putByte(long, byte)
-      */
-     public native long allocateDBBMemory(long bytes);
-
-
     /**
      * Resizes a new block of native memory, to the given size in bytes.  The
      * contents of the new block past the size of the old block are
@@ -710,26 +685,6 @@ public final class Unsafe {
         checkPointer(null, address);
         checkSize(bytes);
     }
-
-     /**
-      * Resizes a new block of native memory for DirectByteBuffers, to the
-      * given size in bytes.  The contents of the new block past the size of
-      * the old block are uninitialized; they will generally be garbage.  The
-      * resulting native pointer will be zero if and only if the requested size
-      * is zero.  The resulting native pointer will be aligned for all value
-      * types.  Dispose of this memory by calling {@link #freeDBBMemory}, or
-      * resize it with {@link #reallocateDBBMemory}.  The address passed to
-      * this method may be null, in which case an allocation will be performed.
-      *
-      * @throws IllegalArgumentException if the size is negative or too large
-      *         for the native size_t type
-      *
-      * @throws OutOfMemoryError if the allocation is refused by the system
-      *
-      * @see #allocateDBBMemory
-      */
-     public native long reallocateDBBMemory(long address, long bytes);
-
 
     /**
      * Sets all bytes in a given block of memory to a fixed value
@@ -962,15 +917,6 @@ public final class Unsafe {
     private void freeMemoryChecks(long address) {
         checkPointer(null, address);
     }
-
-    /**
-      * Disposes of a block of native memory, as obtained from {@link
-      * #allocateDBBMemory} or {@link #reallocateDBBMemory}.  The address passed
-      * to this method may be null, in which case no action is taken.
-      *
-      * @see #allocateDBBMemory
-      */
-     public native void freeDBBMemory(long address);
 
     /// random queries
 


### PR DESCRIPTION
OpenJ9 overwrites this file now, so the extensions are no longer
required to make this file compatible with OpenJ9.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>