### PR TITLE
Enable DDR support for Linux x86-64

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -277,7 +277,13 @@ endif
 SPEC_SED_SCRIPT := -e 's/gcc-4.6/gcc/g'
 
 # Adjust DDR enablement flags.
-SPEC_SED_SCRIPT += $(call SedDisable,module_ddr)
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  FEATURE_SED_SCRIPT += $(call SedEnable,opt_useOmrDdr)
+  SPEC_SED_SCRIPT    += $(call SedEnable,module_ddr)
+else
+  FEATURE_SED_SCRIPT += $(call SedDisable,opt_useOmrDdr)
+  SPEC_SED_SCRIPT    += $(call SedDisable,module_ddr)
+endif
 
 # Disable windows rebase.
 SPEC_SED_SCRIPT += $(call SedDisable,uma_windowsRebase)
@@ -412,6 +418,12 @@ endif
 	@$(CP) -p $(OUTPUT_ROOT)/vm/redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
 	@$(MKDIR) -p $(MODULES_LIBS_DIR)/java.base/server
 	@$(CP) -p $(OUTPUT_ROOT)/vm/redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/server/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+	@$(ECHO) Copying j9ddr.dat
+	@$(MKDIR) -p $(MODULES_LIBS_DIR)/java.base/$(OPENJ9_LIBS_SUBDIR)
+	@$(CP) -p $(OUTPUT_ROOT)/vm/j9ddr.dat $(MODULES_LIBS_DIR)/java.base/$(OPENJ9_LIBS_SUBDIR)/
+endif
 
 J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl_sources.done
 

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -47,6 +47,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJDK_VERSION_DETAILS
   OPENJ9_CONFIGURE_CMAKE
   OPENJ9_CONFIGURE_CUDA
+  OPENJ9_CONFIGURE_DDR
   OPENJ9_CONFIGURE_NUMA
   OPENJ9_THIRD_PARTY_REQUIREMENTS
 ])
@@ -134,6 +135,31 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
   AC_SUBST(OPENJ9_ENABLE_CUDA)
   AC_SUBST(OPENJ9_CUDA_HOME)
   AC_SUBST(OPENJ9_GDK_HOME)
+])
+
+AC_DEFUN([OPENJ9_CONFIGURE_DDR],
+[
+  AC_MSG_CHECKING([for ddr])
+  AC_ARG_ENABLE([ddr], [AS_HELP_STRING([--enable-ddr], [enable DDR support @<:@disabled@:>@])])
+  if test "x$enable_ddr" = xyes ; then
+    AC_MSG_RESULT([yes (explicitly enabled)])
+    OPENJ9_ENABLE_DDR=true
+  elif test "x$enable_ddr" = xno ; then
+    AC_MSG_RESULT([no (explicitly disabled)])
+    OPENJ9_ENABLE_DDR=false
+  elif test "x$enable_ddr" = x ; then
+    if test "x$OPENJ9_PLATFORM_CODE" = xxa64 ; then
+      AC_MSG_RESULT([yes (default for xa64)])
+      OPENJ9_ENABLE_DDR=true
+    else
+      AC_MSG_RESULT([no (default)])
+      OPENJ9_ENABLE_DDR=false
+    fi
+  else
+    AC_MSG_ERROR([--enable-ddr accepts no argument])
+  fi
+
+  AC_SUBST(OPENJ9_ENABLE_DDR)
 ])
 
 AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,10 +1,9 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-# 
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -14,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
 # ===========================================================================
 
 # This macro is called to allow inclusion of closed source counterparts.
@@ -44,6 +42,9 @@ endif
 ifneq (,@OPENJ9_GDK_HOME@)
 export GDK_HOME         := @OPENJ9_GDK_HOME@
 endif
+
+## DDR
+OPENJ9_ENABLE_DDR       := @OPENJ9_ENABLE_DDR@
 
 # for constructing version output
 COMPILER_VERSION_STRING := @COMPILER_VERSION_STRING@

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -963,6 +963,7 @@ SPEC
 SDKROOT
 XCODEBUILD
 FREEMARKER_JAR
+OPENJ9_ENABLE_DDR
 OPENJ9_GDK_HOME
 OPENJ9_CUDA_HOME
 OPENJ9_ENABLE_CUDA
@@ -1150,6 +1151,7 @@ with_cmake
 with_cuda
 with_gdk
 enable_cuda
+enable_ddr
 with_freemarker_jar
 with_devkit
 with_sys_root
@@ -2009,6 +2011,7 @@ Optional Features:
   --enable-debug          set the debug level to fastdebug (shorthand for
                           --with-debug-level=fastdebug) [disabled]
   --enable-cuda           enable CUDA support [disabled]
+  --enable-ddr            enable DDR support [disabled]
   --enable-headless-only  only build headless (no GUI) support [disabled]
   --enable-full-docs      build complete documentation [enabled if all tools
                           found]
@@ -5224,7 +5227,7 @@ VS_SDK_PLATFORM_NAME_2013=
 # definitions. It is replaced with custom functionality when building
 # custom sources.
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -5263,8 +5266,10 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 
+
+
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1517096419
+DATE_WHEN_GENERATED=1519897402
 
 ###############################################################################
 #
@@ -17651,6 +17656,38 @@ $as_echo "no (default)" >&6; }
   fi
 
 
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ddr" >&5
+$as_echo_n "checking for ddr... " >&6; }
+  # Check whether --enable-ddr was given.
+if test "${enable_ddr+set}" = set; then :
+  enableval=$enable_ddr;
+fi
+
+  if test "x$enable_ddr" = xyes ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (explicitly enabled)" >&5
+$as_echo "yes (explicitly enabled)" >&6; }
+    OPENJ9_ENABLE_DDR=true
+  elif test "x$enable_ddr" = xno ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (explicitly disabled)" >&5
+$as_echo "no (explicitly disabled)" >&6; }
+    OPENJ9_ENABLE_DDR=false
+  elif test "x$enable_ddr" = x ; then
+    if test "x$OPENJ9_PLATFORM_CODE" = xxa64 ; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (default for xa64)" >&5
+$as_echo "yes (default for xa64)" >&6; }
+      OPENJ9_ENABLE_DDR=true
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (default)" >&5
+$as_echo "no (default)" >&6; }
+      OPENJ9_ENABLE_DDR=false
+    fi
+  else
+    as_fn_error $? "--enable-ddr accepts no argument" "$LINENO" 5
+  fi
 
 
 

--- a/closed/make/DDR-gensrc.gmk
+++ b/closed/make/DDR-gensrc.gmk
@@ -1,0 +1,90 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# The main target.
+all :
+
+ifeq (,$(wildcard $(SPEC)))
+  $(error BuildDDR.gmk needs SPEC set to a proper spec.gmk)
+endif
+
+include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
+include $(SRC_ROOT)/make/common/JavaCompilation.gmk
+include $(SRC_ROOT)/make/common/SetupJavaCompilers.gmk
+
+# Supporting definitions.
+DDR_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/ddr
+DDR_VM_SRC_ROOT := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
+
+#############################################################################
+
+# Build a jar containing the code generators.
+$(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
+	SETUP := GENERATE_OLDBYTECODE, \
+	BIN := $(DDR_SUPPORT_DIR)/tools, \
+	CLASSPATH := $(addprefix $(JDK_OUTPUTDIR)/modules/, java.base openj9.dtfj), \
+	SRC := $(DDR_VM_SRC_ROOT), \
+	INCLUDE_FILES := $(addsuffix .java,$(subst .,/, \
+		com.ibm.j9ddr.BytecodeGenerator \
+		com.ibm.j9ddr.CTypeParser \
+		com.ibm.j9ddr.StructureHeader \
+		com.ibm.j9ddr.StructureReader \
+		com.ibm.j9ddr.StructureTypeManager \
+		com.ibm.j9ddr.logging.LoggerNames \
+		com.ibm.j9ddr.tools.FlagStructureList \
+		com.ibm.j9ddr.tools.PointerGenerator \
+		com.ibm.j9ddr.tools.StructureStubGenerator \
+		com.ibm.j9ddr.tools.store.J9DDRStructureStore \
+		com.ibm.j9ddr.tools.store.StructureKey \
+		com.ibm.j9ddr.tools.store.StructureMismatchError \
+		)), \
+	))
+
+#############################################################################
+
+# The superset file is built with the VM.
+DDR_SUPERSET_FILE := $(OUTPUT_ROOT)/vm/superset.dat
+
+# Generate Java pointer classes.
+DDR_POINTERS_MARKER := $(DDR_SUPPORT_DIR)/pointers.done
+
+$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+	@$(ECHO) Generating DDR pointer classes
+	@$(RM) -rf $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/vm29/pointer/generated/
+	@$(JAVA) -cp $(BUILD_DDR_TOOLS_BIN) com.ibm.j9ddr.tools.PointerGenerator \
+		-f $(dir $(DDR_SUPERSET_FILE)) \
+		-s $(notdir $(DDR_SUPERSET_FILE)) \
+		-p com.ibm.j9ddr.vm29.pointer.generated \
+		-v 29 \
+		-o $(DDR_VM_SRC_ROOT)
+	@$(TOUCH) $@
+
+# Generate Java structure stub classes.
+DDR_STRUCTURES_MARKER := $(DDR_SUPPORT_DIR)/structures.done
+
+$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+	@$(ECHO) Generating DDR structure stubs
+	@$(RM) -rf $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/vm29/structure/
+	@$(JAVA) -cp $(BUILD_DDR_TOOLS_BIN) com.ibm.j9ddr.tools.StructureStubGenerator \
+		-f $(dir $(DDR_SUPERSET_FILE)) \
+		-s $(notdir $(DDR_SUPERSET_FILE)) \
+		-p com.ibm.j9ddr.vm29.structure \
+		-o $(DDR_VM_SRC_ROOT)
+	@$(TOUCH) $@
+
+all : $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)

--- a/closed/make/DDR-jar.gmk
+++ b/closed/make/DDR-jar.gmk
@@ -1,0 +1,64 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# The main target.
+all :
+
+ifeq (,$(wildcard $(SPEC)))
+  $(error BuildDDR.gmk needs SPEC set to a proper spec.gmk)
+endif
+
+include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
+include $(SRC_ROOT)/make/common/JavaCompilation.gmk
+include $(SRC_ROOT)/make/common/SetupJavaCompilers.gmk
+
+# Supporting definitions.
+DDR_CLASSES_BIN := $(SUPPORT_OUTPUTDIR)/ddr/classes
+
+# We depend upon class files from these modules.
+DDR_CLASSPATH := $(addprefix $(JDK_OUTPUTDIR)/modules/, \
+		java.base \
+		java.desktop \
+		openj9.dtfj \
+		openj9.traceformat \
+	)
+
+DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
+
+ifeq (,$(filter mz31 mz64,$(OPENJ9_PLATFORM_CODE)))
+DDR_SRC_EXCLUDES += com/ibm/j9ddr/corereaders/tdump
+endif
+
+$(eval $(call SetupJavaCompilation,BUILD_DDR_CLASSES, \
+	SETUP := GENERATE_USINGJDKBYTECODE, \
+	BIN := $(DDR_CLASSES_BIN), \
+	CLASSPATH := $(DDR_CLASSPATH), \
+	SRC := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, \
+	EXCLUDES := $(DDR_SRC_EXCLUDES), \
+	COPY := com/ibm/j9ddr/StructureAliases29.dat, \
+	))
+
+$(eval $(call SetupJarArchive,BUILD_DDR_JAR, \
+	DEPENDENCIES := $(BUILD_DDR_CLASSES), \
+	SRCS := $(DDR_CLASSES_BIN), \
+	SUFFIXES := .class .dat .properties, \
+	EXCLUDES := com/ibm/j9ddr/vm29/structure, \
+	JAR := $(call FindLibDirForModule, openj9.dtfj)/ddr/j9ddr.jar, \
+	))
+
+all : $(BUILD_DDR_JAR)

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,10 +1,9 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-# 
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -14,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
 # ===========================================================================
 
 CLEAN_DIRS += vm
@@ -43,5 +41,19 @@ openj9-jdk-image : jdk-image j9vm-build
 
 openj9-jre-image : jre-image j9vm-build
 	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_jre_image)
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+
+.PHONY : openj9.dtfj-ddr-gensrc openj9.dtfj-ddr-jar
+
+openj9.dtfj-ddr-gensrc : j9vm-build $(addsuffix -java, java.base java.desktop openj9.dtfj openj9.traceformat)
+	+$(MAKE) -f $(SRC_ROOT)/closed/make/DDR-gensrc.gmk SPEC=$(SPEC)
+
+openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gensrc
+	+$(MAKE) -f $(SRC_ROOT)/closed/make/DDR-jar.gmk SPEC=$(SPEC)
+
+openj9.dtfj-jmod : openj9.dtfj-ddr-jar
+
+endif # OPENJ9_ENABLE_DDR
 
 ALL_TARGETS += openj9-jdk-image openj9-jre-image

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5198,7 +5198,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1517096419
+DATE_WHEN_GENERATED=1519897402
 
 ###############################################################################
 #


### PR DESCRIPTION
* add configure option '--enable-ddr' (enabled by default for xa64)
* enable opt_useOmrDdr accordingly
* build j9ddr.jar for inclusion in openj9.dtfj.jmod

Depends on eclipse/openj9#1399.