### PR TITLE
Fix race condition in jdwp

### DIFF
--- a/jdk/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.h
+++ b/jdk/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.h
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 /*
  * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -39,4 +61,6 @@ void debugInit_reset(JNIEnv *env);
 void debugInit_exit(jvmtiError, const char *);
 void forceExit(int);
 
+void debugInit_waitVMInitComplete(void);
+void signalVMInitComplete(void);
 #endif

--- a/jdk/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/jdk/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 /*
  * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -98,7 +120,8 @@ debugLoop_run(void)
     standardHandlers_onConnect();
     threadControl_onConnect();
 
-    /* Okay, start reading cmds! */
+    debugInit_waitVMInitComplete();
+	/* Okay, start reading cmds! */
     while (shouldListen) {
         if (!dequeue(&p)) {
             break;

--- a/jdk/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
+++ b/jdk/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
@@ -1,3 +1,25 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
 /*
  * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -574,6 +596,7 @@ handleReportVMInitCommand(JNIEnv* env, ReportVMInitCommand *command)
         (void)threadControl_suspendThread(command->thread, JNI_FALSE);
     }
 
+	signalVMInitComplete();
     outStream_initCommand(&out, uniqueID(), 0x0,
                           JDWP_COMMAND_SET(Event),
                           JDWP_COMMAND(Event, Composite));


### PR DESCRIPTION
Normally, the event helper thread suspends all threads, then the debug loop in
the listener thread receives a command to resume.  The debugger may deadlock if
the debug loop in the listener thread starts processing commands (e.g. resume
threads) before the event helper completes the initialization (and suspends
threads).

This patch adds synchronization to ensure the event helper completes the
initialization sequence before debugger commands are processed.

@andrew-m-leonard FYI.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>