### PR TITLE
Fix discovery of most recent git tag

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -235,11 +235,11 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
 AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
 [
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${OPENJDK_SHA}"`
-
-  if test "x$OPENJDK_TAG" = x; then
-    LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
-    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${LAST_TAGGED_REVISION}"`
+  LAST_TAGGED_SHA=`git -C $SRC_ROOT rev-list --tags="jdk-9*" --max-count=1 2>/dev/null`
+  if test "x$LAST_TAGGED_SHA" != x; then
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "$LAST_TAGGED_SHA"`
+  else
+    OPENJDK_TAG=
   fi
 
   AC_SUBST(OPENJDK_SHA)

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -5273,7 +5273,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1521660908
+DATE_WHEN_GENERATED=1523293287
 
 ###############################################################################
 #
@@ -17199,11 +17199,11 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
 
 
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${OPENJDK_SHA}"`
-
-  if test "x$OPENJDK_TAG" = x; then
-    LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
-    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk-9*" "${LAST_TAGGED_REVISION}"`
+  LAST_TAGGED_SHA=`git -C $SRC_ROOT rev-list --tags="jdk-9*" --max-count=1 2>/dev/null`
+  if test "x$LAST_TAGGED_SHA" != x; then
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "$LAST_TAGGED_SHA"`
+  else
+    OPENJDK_TAG=
   fi
 
 

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5202,7 +5202,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1521660908
+DATE_WHEN_GENERATED=1523293287
 
 ###############################################################################
 #


### PR DESCRIPTION
Now detects both annotated and unannotated tags.