### PR TITLE
Fix default target: exploded-image

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -142,6 +142,7 @@ endif
 	clean-j9 \
 	clean-j9-dist \
 	generate-j9jcl-sources \
+	openj9_build_jdk \
 	run-preprocessors-j9 \
 	stage-j9 \
 	stage-openj9-tools \
@@ -150,69 +151,60 @@ endif
 
 # generated_target_rules_build
 # ----------------------------
-# param 1 = The jdk/jre directory name
+# param 1 = The make goal
 # param 2 = The jdk/jre directory to add openj9 content
 define generated_target_rules_build
 
-.PHONY : stage_openj9_$1
+.PHONY : $1
 
 $(foreach file,$(OPENJ9_ALT_SHARED_LIBRARIES) $(OPENJ9_BUILD_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_NOTICE_FILES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(file),$(SRC_ROOT)/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/$(file),$(SRC_ROOT)/$(file))))
 
 $(foreach file,$(OPENJ9_REDIRECTOR), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$(MODULES_LIBS_DIR)/java.base/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$(MODULES_LIBS_DIR)/java.base/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$(MODULES_LIBS_DIR)/openj9.sharedclasses/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$(MODULES_LIBS_DIR)/openj9.sharedclasses/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_MANAGEMENT_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$(MODULES_LIBS_DIR)/java.management/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$(MODULES_LIBS_DIR)/java.management/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 
 endef
 
 # generated_target_rules
 # ----------------------
-# param 1 = The jdk/jre directory name
+# param 1 = The make goal
 # param 2 = The jdk/jre directory to add openj9 content
 define generated_target_rules
 
-.PHONY : stage_openj9_$1
+.PHONY : $1
 
 $(foreach file,$(OPENJ9_SHARED_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/lib/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_NOTICE_FILES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(file),$(SRC_ROOT)/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/$(file),$(SRC_ROOT)/$(file))))
 
 $(foreach file,$(OPENJ9_REDIRECTOR), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
-
-ifneq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
-
-# For cross compiles we need some extra libraries defined for use in the generated target rules section.
-# These are libraries that would normally be copied as part of the build jdk rules, but that section is currently
-# not active during cross compilation. Once we have a working build jdk as part of the build it will probably be possible
-# to remove these declarations.
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUT_ROOT)/vm/$(file))))
 
 $(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,stage_openj9_$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
-
-endif # cross compile
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUT_ROOT)/vm/$(file))))
 
 endef
 
@@ -238,21 +230,25 @@ endef
 
 OPENJ9_MARKER_FILE := .up-to-date
 
-# Use '-m' / '--touch' to avoid file modification times (`-m` works with older tar tools).
+# Use '-m' / '--touch' to avoid file modification times ('-m' works with older tar implementations).
 define openj9_copy_tree_impl
 	@$(MKDIR) -p $1
 	@$(TAR) --create --directory=$2 $(if $(wildcard $1/$(OPENJ9_MARKER_FILE)),--newer=$1/$(OPENJ9_MARKER_FILE)) --exclude-vcs . | $(TAR) --extract --directory=$1 -m
 	@$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
 
-# Temporary fix until we work out how to handle the build_jdk for cross compiles
-ifeq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
-  $(eval $(call generated_target_rules_build,build_jdk,$(BUILD_JDK)))
-else
-  $(info Cross compilation detected, skipping generated_target_rules_build)
+openj9_build_jdk : build-j9
+ifeq ($(BUILD_JDK),$(JDK_OUTPUTDIR))
+	+$(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk create_build_jdk
 endif
-$(eval $(call generated_target_rules,jdk_image,$(JDK_IMAGE_DIR)))
-$(eval $(call generated_target_rules,jre_image,$(JRE_IMAGE_DIR)))
+
+# If we weren't given a BUILD_JDK, we must create one.
+ifeq ($(BUILD_JDK),$(JDK_OUTPUTDIR))
+  $(eval $(call generated_target_rules_build,create_build_jdk,$(JDK_OUTPUTDIR)))
+endif
+
+$(eval $(call generated_target_rules,openj9_jdk_image,$(JDK_IMAGE_DIR)))
+$(eval $(call generated_target_rules,openj9_jre_image,$(JRE_IMAGE_DIR)))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:
@@ -314,9 +310,8 @@ stage-openj9-tools :
 
 build-openj9-tools : stage-openj9-tools
 	@$(ECHO) Building OpenJ9 tools
-	($(MAKE) $(MAKEFLAGS) -C $(OUTPUT_ROOT)/vm/sourcetools -f buildj9tools.mk \
-		JAVA_HOME=$(BOOT_JDK) lib/jpp.jar \
-	)
+	$(MAKE) -C $(OUTPUT_ROOT)/vm/sourcetools $(MAKEFLAGS) -f buildj9tools.mk \
+		JAVA_HOME=$(BOOT_JDK) lib/jpp.jar
 
 stage-j9 : stage-openj9-tools
 	@$(ECHO) Staging OpenJ9 debugtools in $(OUTPUT_ROOT)/vm
@@ -372,9 +367,8 @@ run-preprocessors-j9 : stage-j9 \
 		$(OUTPUT_ROOT)/vm/compiler/jit.version \
 		$(OUTPUT_ROOT)/vm/include/openj9_version_info.h
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)
-	(export BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) \
-		&& cd $(OUTPUT_ROOT)/vm \
-		&& $(MAKE) $(MAKEFLAGS) -f buildtools.mk \
+	export BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) \
+		&& $(MAKE) -C $(OUTPUT_ROOT)/vm $(MAKEFLAGS) -f buildtools.mk \
 			BUILD_ID=$(BUILD_ID) \
 			CMAKE=$(CMAKE) \
 			EXTRA_CONFIGURE_ARGS=$(OMR_EXTRA_CONFIGURE_ARGS) \
@@ -385,21 +379,16 @@ run-preprocessors-j9 : stage-j9 \
 			OPENJ9_BUILD=true \
 			SPEC=$(OPENJ9_BUILDSPEC) \
 			UMA_OPTIONS_EXTRA="-buildDate $(shell date +'%Y%m%d')" \
-			tools \
-	)
+			tools
 
 build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUT_ROOT)/vm
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-	(export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) \
-		&& cd $(OUTPUT_ROOT)/vm/build \
-		&& $(MAKE) $(MAKEFLAGS) install \
-	)
+	export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) \
+		&& $(MAKE) -C $(OUTPUT_ROOT)/vm/build $(MAKEFLAGS) install
 else
-	(export OPENJ9_BUILD=true $(EXPORT_NO_USE_MINGW) $(EXPORT_MSVS_ENV_VARS) \
-		&& cd $(OUTPUT_ROOT)/vm \
-		&& $(MAKE) $(MAKEFLAGS) all \
-	)
+	export OPENJ9_BUILD=true $(EXPORT_NO_USE_MINGW) $(EXPORT_MSVS_ENV_VARS) \
+		&& $(MAKE) -C $(OUTPUT_ROOT)/vm $(MAKEFLAGS) all
 endif
 	@$(ECHO) OpenJ9 compile complete
 
@@ -455,7 +444,7 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 generate-j9jcl-sources : $(J9JCL_SOURCES_DONEFILE)
 
 clean-j9 : clean-openj9-thirdparty-binaries
-	(cd $(OUTPUT_ROOT)/vm && $(MAKE) clean)
+	$(MAKE) -C $(OUTPUT_ROOT)/vm clean
 
 clean-j9-dist : clean-openj9-thirdparty-binaries
 	$(RM) -fdr $(OUTPUT_ROOT)/vm

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -19,28 +19,25 @@ CLEAN_DIRS += vm
 
 .PHONY : \
 	j9vm-build \
-	j9vm-compose-buildjvm \
 	openj9-jdk-image \
 	openj9-jre-image \
+	java.base-libs \
 	#
 
-j9vm-build :
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR) build-j9)
+OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR)
 
-j9vm-compose-buildjvm : j9vm-build
-ifeq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)
-else
-	@$(ECHO) Cross compile detected, skipping stage_openj9_build_jdk
-endif
+java.base-libs : java.base-copy j9vm-build
+
+j9vm-build : buildtools-langtools
+	+$(OPENJ9_MAKE) openj9_build_jdk
 
 product-images : openj9-jdk-image openj9-jre-image
 
 openj9-jdk-image : jdk-image j9vm-build
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_jdk_image)
+	+$(OPENJ9_MAKE) openj9_jdk_image
 
 openj9-jre-image : jre-image j9vm-build
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_jre_image)
+	+$(OPENJ9_MAKE) openj9_jre_image
 
 ifeq (true,$(OPENJ9_ENABLE_DDR))
 

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1,5 +1,5 @@
 #
-# (c) Copyright IBM Corp. 2011, 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2011, 2018 All Rights Reserved
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -701,7 +701,7 @@ else
   endif
 
   # Building java.base-jmod requires all of hotspot to be built.
-  java.base-jmod: j9vm-compose-buildjvm
+  java.base-jmod: j9vm-build
 
   # Declare dependencies from <module>-jmod to all other module targets
   # When creating a BUILDJDK, the java compilation has already been done by the
@@ -727,7 +727,7 @@ else
   # in java.base-copy) and tzdb.dat (done in java.base-gendata) to the
   # appropriate location otherwise jimage, jlink and jmod won't start. This
   # also applies when creating the buildjdk.
-  DEFAULT_JMOD_DEPS := j9vm-compose-buildjvm java.base-libs java.base-copy java.base-gendata \
+  DEFAULT_JMOD_DEPS := java.base-libs java.base-copy java.base-gendata \
       jdk.jlink-launchers
   # When cross compiling and buildjdk is to be created, depend on creating the
   # buildjdk instead of the default dependencies.
@@ -787,7 +787,7 @@ else
   # populated (java, copy and gendata targets) and the basic libs and launchers
   # have been built.
   exploded-image-optimize: java copy gendata java.base-libs java.base-launchers \
-      buildtools-modules j9vm-build 
+      buildtools-modules
 
   bootcycle-images: jdk-image
 
@@ -922,8 +922,6 @@ ifneq ($(COMPILE_TYPE), cross)
   exploded-image: exploded-image-optimize
 endif
 
-j9vm-build: buildtools-langtools 
-java.base-libs: j9vm-build
 create-buildjdk: create-buildjdk-copy create-buildjdk-interim-image
 
 docs-jdk-api: docs-jdk-api-javadoc


### PR DESCRIPTION
Adjust build rules to satisfy expectations of `exploded-image` make target.

* don't use 'make -C' unnecessarily
* don't nest shells unnecessarily
* use consistent make command sequence
* move dependencies to closed/make/Main.gmk

Fixes #34