### PR TITLE
Fix OpenJ9 jvm.dll version for Windows

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -24,7 +24,7 @@ CLEAN_DIRS += vm
 	java.base-libs \
 	#
 
-OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR)
+OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_MAJOR) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS)
 
 java.base-libs : java.base-copy j9vm-build
 


### PR DESCRIPTION
Accompanies https://github.com/eclipse/openj9/pull/2189

Add #165 to the openj9-0.9 branch.
Without this change, trying to build OpenJ9 results in `makelib/mkconstants.mk:507: *** OPENJDK_VERSION_NUMBER_FOUR_POSITIONS is not set from extensions code.  Stop.`

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>