### PR TITLE
Add jvm.cfg for mac osx

### DIFF
--- a/jdk/src/java.base/macosx/conf/x86_64/jvm.cfg
+++ b/jdk/src/java.base/macosx/conf/x86_64/jvm.cfg
@@ -1,3 +1,6 @@
+#
+# (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
+#
 # Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -30,5 +33,8 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
--server KNOWN
--client IGNORE
+-j9vm KNOWN
+-hotspot IGNORE
+-classic IGNORE
+-native IGNORE
+-green IGNORE


### PR DESCRIPTION
Adding this as the mac work started on Java 9.  Will port to the appropriate supported repos once a working build is available.

https://github.com/eclipse/openj9/issues/36

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>