### PR TITLE
Add OSX compressedrefs support in openj9-openjdk-jdk9

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -219,7 +219,11 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
       fi
     elif test "x$OPENJDK_BUILD_OS" = xmacosx; then
       OPENJ9_PLATFORM_CODE=oa64
-      OPENJ9_BUILDSPEC="osx_x86-64"
+      if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+        OPENJ9_BUILDSPEC="osx_x86-64"
+      else
+        OPENJ9_BUILDSPEC="osx_x86-64_cmprssptrs"
+      fi
     else
       AC_MSG_ERROR([Unsupported OpenJ9 platform ${OPENJDK_BUILD_OS}!])
     fi

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -76,3 +76,10 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   export INCLUDE := "@VS_INCLUDE@"
   export LIB := "@VS_LIB@"
 endif
+
+ifeq ($(OPENJDK_BUILD_OS), macosx)
+  ifeq ($(OPENJ9_LIBS_SUBDIR), compressedrefs)
+    # Set page zero size to 4KB for mapping memory below 4GB.
+    LDFLAGS_JDKEXE += -pagezero_size 0x1000
+  endif
+endif

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -5263,7 +5263,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1537309530
+DATE_WHEN_GENERATED=1539281886
 
 ###############################################################################
 #
@@ -17180,7 +17180,11 @@ fi
       fi
     elif test "x$OPENJDK_BUILD_OS" = xmacosx; then
       OPENJ9_PLATFORM_CODE=oa64
-      OPENJ9_BUILDSPEC="osx_x86-64"
+      if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+        OPENJ9_BUILDSPEC="osx_x86-64"
+      else
+        OPENJ9_BUILDSPEC="osx_x86-64_cmprssptrs"
+      fi
     else
       as_fn_error $? "Unsupported OpenJ9 platform ${OPENJDK_BUILD_OS}!" "$LINENO" 5
     fi

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5190,7 +5190,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1537309530
+DATE_WHEN_GENERATED=1539281886
 
 ###############################################################################
 #


### PR DESCRIPTION
Set OPENJ9_BUILDSPEC to osx_x86-64_cmprssptrs for compressedrefs
build.

Append "-pagezero_size 0x1000" to LDFLAGS_JDKEXE on OSX 64-bit
compressedrefs build. This allows memory to be mapped below 4GB.

Ran ./common/autoconf/autogen.sh to re-generate the
generated-configure.sh scripts.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>